### PR TITLE
Fix typo

### DIFF
--- a/ports/juce-host-dev-kit/portfile.cmake
+++ b/ports/juce-host-dev-kit/portfile.cmake
@@ -1,7 +1,7 @@
 ﻿find_program (GIT git)
 
 set (GIT_URL "https://github.com/kyv001/juce-host-dev-kit.git")
-set (GIT_REV "1a5bc08e182b80783e286af5e043e1a1c224b8aa")
+set (GIT_REV "2ce4783104cd5fbe034e7bf9ca7b46a59a50d64c")
 
 set (SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src)
 

--- a/ports/juce-host-dev-kit/portfile.cmake
+++ b/ports/juce-host-dev-kit/portfile.cmake
@@ -1,6 +1,6 @@
 ﻿find_program (GIT git)
 
-set (GIT_URL "https://github.com/Do-sth-sharp/juce-host-dev-kit.git")
+set (GIT_URL "https://github.com/kyv001/juce-host-dev-kit.git")
 set (GIT_REV "1a5bc08e182b80783e286af5e043e1a1c224b8aa")
 
 set (SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src)

--- a/ports/synth-engine-demo/portfile.cmake
+++ b/ports/synth-engine-demo/portfile.cmake
@@ -1,6 +1,6 @@
 ﻿find_program (GIT git)
 
-set (GIT_URL "https://github.com/Do-sth-sharp/SynthEngineDemo.git")
+set (GIT_URL "https://github.com/kyv001/SynthEngineDemo.git")
 set (GIT_REV "d9f068a364e863d8097facd39ecce1a64863fd12")
 
 set (SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src)

--- a/ports/synth-engine-demo/portfile.cmake
+++ b/ports/synth-engine-demo/portfile.cmake
@@ -1,7 +1,7 @@
 ﻿find_program (GIT git)
 
 set (GIT_URL "https://github.com/kyv001/SynthEngineDemo.git")
-set (GIT_REV "d9f068a364e863d8097facd39ecce1a64863fd12")
+set (GIT_REV "3c3adeec6a6b41597e8009e4a263484521262cf2")
 
 set (SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src)
 

--- a/toolchains/win-llvm.cmake
+++ b/toolchains/win-llvm.cmake
@@ -43,16 +43,16 @@
     endforeach()
 
     # Set Compilers
-    find_program(CLANG_EXECUTBALE NAMES "clang" "clang.exe" PATHS ENV LLVMInstallDir PATH_SUFFIXES "bin" NO_DEFAULT_PATH)
-    find_program(CLANG_EXECUTBALE NAMES "clang" "clang.exe" PATHS ENV LLVMInstallDir PATH_SUFFIXES "bin")
-    find_program(CLANG_EXECUTBALE NAMES "clang" "clang.exe" PATHS ENV LLVMInstallDir NO_DEFAULT_PATH)
-    find_program(CLANG_EXECUTBALE NAMES "clang" "clang.exe" PATHS ENV LLVMInstallDir)
+    find_program(CLANG_EXECUTABLE NAMES "clang" "clang.exe" PATHS ENV LLVMInstallDir PATH_SUFFIXES "bin" NO_DEFAULT_PATH)
+    find_program(CLANG_EXECUTABLE NAMES "clang" "clang.exe" PATHS ENV LLVMInstallDir PATH_SUFFIXES "bin")
+    find_program(CLANG_EXECUTABLE NAMES "clang" "clang.exe" PATHS ENV LLVMInstallDir NO_DEFAULT_PATH)
+    find_program(CLANG_EXECUTABLE NAMES "clang" "clang.exe" PATHS ENV LLVMInstallDir)
 
-    if(NOT CLANG_EXECUTBALE)
+    if(NOT CLANG_EXECUTABLE)
       message(SEND_ERROR "Clang was not found!") # Not a FATAL_ERROR due to being a toolchain!
     endif()
 
-    get_filename_component(LLVM_BIN_DIR "${CLANG_EXECUTBALE}" DIRECTORY)
+    get_filename_component(LLVM_BIN_DIR "${CLANG_EXECUTABLE}" DIRECTORY)
     list(INSERT CMAKE_PROGRAM_PATH 0 "${LLVM_BIN_DIR}")
 
     set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "Embedded")


### PR DESCRIPTION
Replaced misspelled `CLANG_EXECUTBALE` with `CLANG_EXECUTABLE`.